### PR TITLE
Observability

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter")
     implementation("org.springframework.cloud:spring-cloud-stream-binder-rabbit")
     implementation("org.springframework.cloud:spring-cloud-starter-config")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
     testImplementation("org.springframework.cloud:spring-cloud-stream-test-binder")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,7 @@ dependencies {
     implementation("org.springframework.cloud:spring-cloud-starter-config")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    runtimeOnly("io.micrometer:micrometer-registry-prometheus")
     testImplementation("org.springframework.cloud:spring-cloud-stream-test-binder")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,8 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
+    runtimeOnly("io.micrometer:micrometer-tracing-bridge-otel")
+    runtimeOnly("io.opentelemetry:opentelemetry-exporter-otlp")
     testImplementation("org.springframework.cloud:spring-cloud-stream-test-binder")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("io.projectreactor:reactor-test")
@@ -49,6 +51,8 @@ tasks.withType<Test> {
 tasks.named<BootBuildImage>("bootBuildImage") {
     environment = mapOf(
         "BP_JVM_VERSION" to "25",
+        "BPE_DELIM_JAVA_TOOL_OPTIONS" to " ",
+        "BPE_APPEND_JAVA_TOOL_OPTIONS" to "-Duser.timezone=Asia/Tokyo",
         "LANG" to "ja_JP.UTF-8",
         "LANGUAGE" to "ja_JP:ja",
         "LC_ALL" to "ja_JP.UTF-8",

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -63,6 +63,10 @@ spec:
               port: 9000
             initialDelaySeconds: 10
             periodSeconds: 5
+          annotations:
+            prometheus.io/scrape: "true"
+            prometheus.io/port: "9001"
+            prometheus.io/path: "/actuator/prometheus"
       volumes:
         - name: tmp
           emptyDir: { }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -13,6 +13,10 @@ spec:
     metadata:
       labels:
         app: dispatcher-service
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9001"
+        prometheus.io/path: "/actuator/prometheus"
     spec:
       securityContext:
         runAsNonRoot: true
@@ -63,10 +67,6 @@ spec:
               port: 9000
             initialDelaySeconds: 10
             periodSeconds: 5
-          annotations:
-            prometheus.io/scrape: "true"
-            prometheus.io/port: "9001"
-            prometheus.io/path: "/actuator/prometheus"
       volumes:
         - name: tmp
           emptyDir: { }

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -15,7 +15,7 @@ spec:
         app: dispatcher-service
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "9001"
+        prometheus.io/port: "9003"
         prometheus.io/path: "/actuator/prometheus"
     spec:
       securityContext:
@@ -58,13 +58,13 @@ spec:
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
-              port: 9000
+              port: 9003
             initialDelaySeconds: 10
             periodSeconds: 5
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
-              port: 9000
+              port: 9003
             initialDelaySeconds: 10
             periodSeconds: 5
       volumes:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -51,6 +51,18 @@ spec:
             allowPrivilegeEscalation: false
             runAsNonRoot: true
             readOnlyRootFilesystem: true
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 9000
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: tmp
           emptyDir: { }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,17 +31,25 @@ spring:
     username: user
     password: password
     connection-timeout: 5s
-  management:
-    endpoints:
-      web:
-        exposure:
-          include: health,prometheus
-    endpoint:
-      health:
-        show-details: always
-        show-components: always
-        probes:
-          enabled: true
-    metrics:
-      tags:
-        application: ${spring.application.name}
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,prometheus
+  endpoint:
+    health:
+      show-details: always
+      show-components: always
+      probes:
+        enabled: true
+  metrics:
+    tags:
+      application: ${spring.application.name}
+  tracing:
+    sampling:
+      probability: 1.0
+  otlp:
+    tracing:
+      endpoint: http://localhost:4318/v1/traces
+      compression: none
+      timeout: 10s

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -31,3 +31,14 @@ spring:
     username: user
     password: password
     connection-timeout: 5s
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: health
+    endpoint:
+      health:
+        show-details: always
+        show-components: always
+        probes:
+          enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
     endpoints:
       web:
         exposure:
-          include: health
+          include: health,prometheus
     endpoint:
       health:
         show-details: always

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -42,3 +42,6 @@ spring:
         show-components: always
         probes:
           enabled: true
+    metrics:
+      tags:
+        application: ${spring.application.name}


### PR DESCRIPTION
This pull request enhances the observability and reliability of the `dispatcher-service` by introducing Prometheus metrics scraping, health probes, and improved Spring Boot management configuration. The changes ensure that the service can be monitored and diagnosed more effectively in production environments.

**Kubernetes deployment improvements:**

* Added Prometheus annotations to the `dispatcher-service` deployment (`k8s/deployment.yaml`) to enable metrics scraping on port 9001 at `/actuator/prometheus`.
* Introduced `livenessProbe` and `readinessProbe` HTTP checks on port 9000 for `/actuator/health/liveness` and `/actuator/health/readiness`, respectively, improving container health monitoring and automatic recovery.

**Spring Boot management and tracing configuration:**

* Enabled exposure of `health` and `prometheus` endpoints, detailed health information, metrics tagging, and OpenTelemetry tracing with full sampling and OTLP export settings in `application.yml`.